### PR TITLE
🐛 fix: #5 ほうれい線消しの最大強度を拡大

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -117,7 +117,7 @@
     <label>明るさ <input type="range" id="bright" min="0" max="0.3" step="0.01"></label>
     <label>血色 <input type="range" id="warmth" min="0" max="0.2" step="0.01"></label>
     <label>鮮やかさ <input type="range" id="sat" min="0.5" max="1.5" step="0.05"></label>
-    <label>ほうれい線うすめ（右ほど強力） <input type="range" id="nasoA" min="0" max="2" step="0.05"></label>
+    <label>ほうれい線うすめ（右ほど強力） <input type="range" id="nasoA" min="0" max="3" step="0.05"></label>
     <label>目の下の線うすめ（右ほど強力） <input type="range" id="eyebagLine" min="0" max="2" step="0.05"></label>
     <label>クマを明るく <input type="range" id="eyebagBright" min="0" max="1" step="0.05"></label>
     <p class="sub">うまく反映されないとき</p>


### PR DESCRIPTION
## 概要

ほうれい線うすめスライダー（`nasoA`）の最大値を `2` から `3` に拡大した。

## 変更ファイル

- `popup.html` — `nasoA` スライダーの `max` 属性を `2` → `3` に変更

## 注意点

`override.js` の boost ロジックは既に 3.0 まで対応しているため変更不要。

Closes #5
