### PR TITLE
🐛 fix: #7 眉尻を下げると途切れて消える問題を修正

### DIFF
--- a/override.js
+++ b/override.js
@@ -766,7 +766,7 @@ void main() {
           }
           // 眉尻の高さ: 眉尻に近いほど強く上下にずらす（t^2 で眉頭側は動かない）
           if (settings.browTail !== 0) {
-            const lift = faceW * 0.06 * settings.browTail * t * t;
+            const lift = faceW * 0.035 * settings.browTail * Math.min(t * t, 0.85);
             px += upX * lift;
             py += upY * lift;
           }


### PR DESCRIPTION
## 概要

`browTail` をマイナスにすると眉尻が途切れて消える問題を修正した。移動量の係数が大きすぎ、`t^2` の二乗カーブで端が大きく飛んでいたのが原因。

## 変更ファイル

- `override.js`
  - 眉尻移動量の係数を `0.06` → `0.035` に抑制
  - `t * t` → `Math.min(t * t, 0.85)` で端のジャンプを上限クリップ

Closes #7
