### PR TITLE
💄 ui: #9 セカンダリボタンが無効状態に見える問題を修正

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -83,8 +83,8 @@
     background: #d45f8a; color: #fff; cursor: pointer; font-weight: 600;
   }
   .btn:hover { background: #c14d78; }
-  .btn-sub { background: #e8b3c6; }
-  .btn-sub:hover { background: #dd9cb5; }
+  .btn-sub { background: #fff; color: #d45f8a; border: 1.5px solid #d45f8a; }
+  .btn-sub:hover { background: #fdeef3; }
   .txt, .sel {
     flex: 1; font-size: 11px; padding: 5px 8px;
     border: 1px solid #f0c4d3; border-radius: 8px; background: #fff; color: #5c4a50;


### PR DESCRIPTION
## 概要

「削除」「すべて初期値に戻す」ボタンが薄ピンク背景で disabled に見える問題を修正。セカンダリボタン（`.btn-sub`）をアウトライン（ゴーストボタン）スタイルに変更し、プライマリボタンとの視覚的な区別を明確にした。

## 変更ファイル

- `popup.html`: `.btn-sub` / `.btn-sub:hover` の CSS を薄ピンク塗りつぶしからアウトラインスタイルに変更

## 注意点

CSS のみの変更。動作ロジックへの影響なし。

Closes #9
