### PR TITLE
🐛 fix: #27 最新 Chrome でポップアップの幅が 800px に張り付き右側に余白が出る

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <style>
+  /* 幅の明示を消すとポップアップ窓が最大幅800pxに張り付く（開いた details 内の長文が幅計算に乗るため） */
+  html { width: 300px; }
   body {
     font-family: -apple-system, "Hiragino Maru Gothic ProN", sans-serif;
     width: 290px; padding: 5px; margin: 0;


### PR DESCRIPTION
Closes #27

## 変更内容

`popup.html` の `<style>` に `html { width: 300px; }` を1行追加。

最新の Chrome（151 で確認）で、「はじめに」セクションが開いた状態だとポップアップのウィンドウ幅が最大幅 800px に張り付き、右側に大きな白い余白が出る。`html` 要素に幅の指定がないため、開いている `<details>` 内の長文テキストが幅計算に乗ると推測される（詳細は issue 参照）。

300px の根拠: `body` の占有幅 = 290（width）+ 5×2（padding、既定の `content-box`）= 300px。正常動作環境での `html` 要素の実測値とも一致し、正常な環境では表示は 1px も変わらない。

## 検証

- [x] 構文上の妥当性（HTML の style ブロックへの 1 行追加のみ）
- [ ] **実機確認（未実施・マージ前に必須）**: 「はじめに」を開いた状態でポップアップを開き直し、幅が 300px であること（issue のテスト観点 1〜5）

このリポジトリに CI は無い。検証は実機確認のみ。
