### PR TITLE
💄 ui: #29 ポップアップのスクロールバーを常時表示にして右側の空白帯の違和感をなくす

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,18 @@
     background: #fff;
     color: #5c4a50;
   }
+  ::-webkit-scrollbar { width: 12px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb {
+    background: #f0c4d3;
+    border: 4px solid transparent;
+    background-clip: content-box;
+    border-radius: 6px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    border-width: 2px;
+    background-color: #d45f8a;
+  }
   .panel {
     background: linear-gradient(160deg, #fff5f7 0%, #ffeef3 60%, #fde8ef 100%);
     border-radius: 16px; padding: 10px;


### PR DESCRIPTION
## 概要

ポップアップのスクロールバーを CSS で自前スタイルにして常時表示化。macOS のオーバーレイスクロールバー（操作時のみ表示）による右側の空白帯の違和感を解消する。

## 変更ファイル

- `popup.html`: `<style>` ブロックに `::-webkit-scrollbar` 系のルールを追加（`html`/`body` の直後）
  - トラック幅 12px 固定（レイアウトは動かない）
  - つまみは既存配色の `#f0c4d3`（通常時・透明 border 4px で細く見える）/ `#d45f8a`（hover 時・border 2px で太く見える）を使用。新しい色は導入していない
  - `html { width: 300px; }` の行とその直前の罠警告コメント（#27 対応）は変更していない

## 注意点

以下は実機確認が必要（未検証）。

1. スクロールが必要な状態で、操作していなくても細いバーが右側に見えること
2. バーにマウスオーバーすると太くなること
3. スクロールが不要な状態ではバーも領域も出ず、ウィンドウ幅が 300px のままであること
4. バーの色がパネルの配色と馴染んでいること
5. 横スクロールバーが出ていないこと

Closes #29
