### PR TITLE
🔧 chore: #31 v1.1.2 リリース準備（バージョン bump と package.sh の _locales 同梱漏れ修正）

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "default_locale": "ja",
   "description": "__MSG_extDescription__",
   "permissions": ["storage"],

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -13,6 +13,14 @@ for f in vendor/vision_bundle.mjs vendor/wasm/vision_wasm_internal.js vendor/was
   fi
 done
 
+# _locales が揃っているか確認（default_locale 宣言があるのに _locales が無い zip はストアに弾かれる）
+for f in _locales/ja/messages.json _locales/en/messages.json; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: $f がありません" >&2
+    exit 1
+  fi
+done
+
 VERSION=$(python3 -c "import json; print(json.load(open('manifest.json'))['version'])")
 OUT="dist/simple-makeup-filter-v${VERSION}.zip"
 mkdir -p dist
@@ -28,6 +36,7 @@ zip -r "$OUT" \
   popup.js \
   icons \
   vendor \
+  _locales \
   -x "*.DS_Store"
 
 echo ""


### PR DESCRIPTION
Closes #31

## 変更内容

- `manifest.json` の version を `1.1.1` → `1.1.2`
- `scripts/package.sh` の zip 対象に `_locales` を追加（i18n 対応時の更新漏れ。`default_locale` 宣言があるのに `_locales` が無い zip はストアに受け付けられない）+ `_locales/ja` / `_locales/en` の存在チェックを追加

## 検証

- [x] `bash -n` 構文チェック通過
- [x] `./scripts/package.sh` 実行成功: `dist/simple-makeup-filter-v1.1.2.zip` 生成、`_locales/ja/messages.json` と `_locales/en/messages.json` の同梱を `unzip -l` 出力で確認（22 files）
- [ ] zip 展開ディレクトリの拡張読み込み確認（提出前に実施）

このリポジトリに CI は無い。
