### PR TITLE
🐛 fix: #34 操作パネルを開いたまま Meet をリロードするとガイドのチェック表示が実値とずれる

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -129,6 +129,11 @@ function showParts(parts) {
   }
 }
 
+// 別コンテキストの変更（bridge がページ読み込みで書く全 OFF 等）をチェック表示に反映する
+chrome.storage.onChanged.addListener((changes) => {
+  if (changes.guideParts) showParts(changes.guideParts.newValue);
+});
+
 chrome.storage.local.get(DEFAULTS, (s) => {
   refreshUI(s);
   updateStatus();


### PR DESCRIPTION
Closes #34

## 変更内容

popup.js に chrome.storage.onChanged のリスナを追加し、guideParts の変更（bridge がページ読み込み時に書く全 OFF 等）をチェックボックス表示に反映する（5行）。

## 検証

- [x] node --check 通過
- [ ] 実機: パネルを開いたまま Meet をリロード → チェックが全 OFF に変わる（再現しない環境では従来挙動に影響がないことのみ確認）

CI 無し。検証は rule-checker + 実機。