### PR TITLE
✨ feat: #38 涙袋メイク（下瞼のアイシャドウ）をハイライト + シェイドの2層で追加する

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -70,6 +70,15 @@
   "shadow_soft": { "message": "Softness (sharp ⇔ diffused)" },
   "shadow_bias": { "message": "Crease ratio (even ⇔ crease-heavy)" },
 
+  "tear_title": { "message": "💧 Under-eye" },
+  "tear_color_title": { "message": "Highlight color" },
+  "tear_shade_color_title": { "message": "Shadow line color" },
+  "tear_a": { "message": "Opacity" },
+  "tear_shade_a": { "message": "Shadow opacity" },
+  "tear_h": { "message": "Height (narrow ⇔ wide)" },
+  "tear_w": { "message": "Width (narrow ⇔ wide)" },
+  "tear_soft": { "message": "Softness (sharp ⇔ diffused)" },
+
   "liner_title": { "message": "✒️ Eyeliner" },
   "liner_color_title": { "message": "Liner color" },
   "liner_a": { "message": "Opacity" },
@@ -116,6 +125,7 @@
   "guide_part_blush": { "message": "Blush guide line" },
   "guide_part_brow": { "message": "Brows guide line" },
   "guide_part_shadow": { "message": "Eyeshadow guide line" },
+  "guide_part_tear": { "message": "Under-eye highlight guide line" },
   "guide_part_liner": { "message": "Eyeliner guide line" },
   "guide_part_nose": { "message": "Nose shadow guide line" },
   "guide_part_jaw": { "message": "Jawline guide line" },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -70,6 +70,15 @@
   "shadow_soft": { "message": "ぼかし（くっきり ⇔ ふんわり）" },
   "shadow_bias": { "message": "際色の量（均等 ⇔ 際多め）" },
 
+  "tear_title": { "message": "💧 涙袋" },
+  "tear_color_title": { "message": "ハイライト色" },
+  "tear_shade_color_title": { "message": "影の色" },
+  "tear_a": { "message": "濃さ" },
+  "tear_shade_a": { "message": "影の濃さ" },
+  "tear_h": { "message": "高さ（狭 ⇔ 広）" },
+  "tear_w": { "message": "横幅（狭 ⇔ 広）" },
+  "tear_soft": { "message": "ぼかし（くっきり ⇔ ふんわり）" },
+
   "liner_title": { "message": "✒️ アイライン" },
   "liner_color_title": { "message": "アイライン色" },
   "liner_a": { "message": "濃さ" },
@@ -116,6 +125,7 @@
   "guide_part_blush": { "message": "チークのガイド線" },
   "guide_part_brow": { "message": "眉のガイド線" },
   "guide_part_shadow": { "message": "アイシャドウのガイド線" },
+  "guide_part_tear": { "message": "涙袋のガイド線" },
   "guide_part_liner": { "message": "アイラインのガイド線" },
   "guide_part_nose": { "message": "ノーズシャドウのガイド線" },
   "guide_part_jaw": { "message": "輪郭のガイド線" },

--- a/defaults.js
+++ b/defaults.js
@@ -14,6 +14,7 @@ globalThis.MBF_GUIDE_COLORS = {
   blush: '#ff7fbf',
   brow: '#8b5a2b',
   shadow: '#b14cff',
+  tear: '#ff2ed1',
   liner: '#2f6bff',
   nose: '#00c853',
   jaw: '#a8e000',
@@ -34,6 +35,7 @@ globalThis.MBF_DEFAULTS = {
     blush: false,
     brow: false,
     shadow: false,
+    tear: false,
     liner: false,
     nose: false,
     jaw: false,
@@ -94,6 +96,15 @@ globalThis.MBF_DEFAULTS = {
   shadowW: 1.0,    // 幅 0.8-1.4
   shadowSoft: 1.0, // ぼかし 0.5-3
   shadowBias: 1.0, // 際色の量 1-3
+
+  // --- 涙袋 ---
+  tearColor: '#f0d5cd',      // ハイライト色
+  tearShadeColor: '#c9a396', // シェイド色（影線）
+  tearA: 0,       // ハイライト濃さ 0-1
+  tearShadeA: 0,  // シェイド濃さ 0-1
+  tearH: 1.0,     // 高さ（帯の広さ） 0.5-2
+  tearW: 1.0,     // 横幅 0.8-1.4
+  tearSoft: 1.0,  // ぼかし 0.5-3
 
   // --- アイライン ---
   linerColor: '#2b1d1a',

--- a/override.js
+++ b/override.js
@@ -263,6 +263,7 @@ void main() {
     blush: '#ff7fbf',
     brow: '#8b5a2b',
     shadow: '#b14cff',
+    tear: '#ff2ed1',
     liner: '#2f6bff',
     nose: '#00c853',
     jaw: '#a8e000',
@@ -517,6 +518,32 @@ void main() {
     return pts;
   }
 
+  // 涙袋の帯: 下まぶたの際ラインを顔基準の下方向へ押し出した閉領域。
+  // lid = 際側の点列、drop = 押し出した側の点列（シェイド線はこの辺に沿って引く）。
+  // 実描画と位置ガイドで同じ形を使う
+  function tearBandPoints(eye, lm, W, H, faceW, roll, upX, upY) {
+    const drop = faceW * 0.03 * settings.tearH;
+    const dirX = Math.cos(roll), dirY = Math.sin(roll);
+    const widen = settings.tearW - 1;
+    let lid = eye.map((i) => [lm[i].x * W, lm[i].y * H]);
+    // 幅: 目の中心を基準に、顔の横方向にだけ伸縮（高さは変えない）
+    if (widen !== 0) {
+      let cx = 0, cy = 0;
+      for (const p of lid) { cx += p[0]; cy += p[1]; }
+      cx /= lid.length; cy /= lid.length;
+      lid = lid.map(([x, y]) => {
+        const d = (x - cx) * dirX + (y - cy) * dirY;
+        return [x + dirX * d * widen, y + dirY * d * widen];
+      });
+    }
+    // 目尻・目頭側は押し出しを狭めて自然な紡錘形にする
+    const lower = lid.map(([x, y], k) => {
+      const edge = k === 0 || k === lid.length - 1 ? 0.4 : 1;
+      return [x - upX * drop * edge, y - upY * drop * edge];
+    });
+    return { lid, lower, drop };
+  }
+
   // アイラインの跳ね上げ三角形の3点（根元2点 + 先端）。実描画と位置ガイドで共有
   function linerWingPoints(eye, lm, W, H, faceW, upX, upY, lw) {
     const ox = lm[eye[0]].x * W, oy = lm[eye[0]].y * H;          // 目尻
@@ -699,6 +726,43 @@ void main() {
         }
         ctx.closePath();
         ctx.fill();
+      }
+    }
+
+    if (settings.tearA > 0 || settings.tearShadeA > 0) {
+      // 涙袋: 下まぶたの際から下へ広がる帯にハイライトを乗せ、その下端に影線を引く。
+      // 明るい色だけでは立体感が出ないため、影線が「ぷっくり」の正体になる
+      ctx.filter = `blur(${Math.max(2, faceW * 0.012 * settings.tearSoft)}px)`;
+      for (const eye of [EYE_BOT_L, EYE_BOT_R]) {
+        const { lid, lower, drop } = tearBandPoints(eye, lm, W, H, faceW, roll, upX, upY);
+
+        if (settings.tearA > 0) {
+          let gx = 0, gy = 0;
+          for (const p of lid) { gx += p[0]; gy += p[1]; }
+          gx /= lid.length; gy /= lid.length;
+          const g = ctx.createLinearGradient(gx, gy, gx - upX * drop, gy - upY * drop);
+          g.addColorStop(0, hexToRgba(settings.tearColor, settings.tearA * 0.45));
+          g.addColorStop(1, hexToRgba(settings.tearColor, 0));
+          ctx.fillStyle = g;
+          ctx.beginPath();
+          ctx.moveTo(lid[0][0], lid[0][1]);
+          for (let k = 1; k < lid.length; k++) ctx.lineTo(lid[k][0], lid[k][1]);
+          for (let k = lower.length - 1; k >= 0; k--) ctx.lineTo(lower[k][0], lower[k][1]);
+          ctx.closePath();
+          ctx.fill();
+        }
+
+        if (settings.tearShadeA > 0) {
+          // 影線は塗りでなく細い線（太いと不自然）
+          ctx.strokeStyle = hexToRgba(settings.tearShadeColor, settings.tearShadeA * 0.5);
+          ctx.lineWidth = Math.max(0.8, faceW * 0.008);
+          ctx.lineCap = 'round';
+          ctx.lineJoin = 'round';
+          ctx.beginPath();
+          ctx.moveTo(lower[0][0], lower[0][1]);
+          for (let k = 1; k < lower.length; k++) ctx.lineTo(lower[k][0], lower[k][1]);
+          ctx.stroke();
+        }
       }
     }
 
@@ -1001,6 +1065,13 @@ void main() {
       }
     }
 
+    if ((settings.tearA > 0 || settings.tearShadeA > 0) && partOn('tear')) {
+      for (const eye of [EYE_BOT_L, EYE_BOT_R]) {
+        const { lid, lower } = tearBandPoints(eye, lm, W, H, faceW, roll, upX, upY);
+        strokePoints(GUIDE_COLORS.tear, lid.concat(lower.slice().reverse()), true);
+      }
+    }
+
     if (settings.linerA > 0 && partOn('liner')) {
       const off = faceW * (settings.linerY ?? 0.002);
       const lw = linerWidth(faceW);
@@ -1202,6 +1273,7 @@ void main() {
           (settings.lipA > 0 || settings.lipGloss > 0 || settings.blushA > 0 || settings.browA > 0 ||
            settings.nasoA > 0 || settings.marioA > 0 || settings.eyebagLine > 0 || settings.eyebagBright > 0 ||
            settings.shadowA > 0 || settings.linerA > 0 ||
+           settings.tearA > 0 || settings.tearShadeA > 0 ||
            settings.noseA > 0 || settings.jawA > 0 ||
            settings.hiA > 0 || settings.hiCheekA > 0 || settings.hiChinA > 0 ||
            anyGuideOn());

--- a/override.js
+++ b/override.js
@@ -733,10 +733,12 @@ void main() {
       // 涙袋: 下まぶたの際から下へ広がる帯にハイライトを乗せ、その下端に影線を引く。
       // 明るい色だけでは立体感が出ないため、影線が「ぷっくり」の正体になる
       ctx.filter = `blur(${Math.max(2, faceW * 0.012 * settings.tearSoft)}px)`;
-      for (const eye of [EYE_BOT_L, EYE_BOT_R]) {
-        const { lid, lower, drop } = tearBandPoints(eye, lm, W, H, faceW, roll, upX, upY);
 
-        if (settings.tearA > 0) {
+      if (settings.tearA > 0) {
+        // ハイライトは screen 合成（multiply のままだとどんな肌色でも暗くなる）
+        ctx.globalCompositeOperation = 'screen';
+        for (const eye of [EYE_BOT_L, EYE_BOT_R]) {
+          const { lid, lower, drop } = tearBandPoints(eye, lm, W, H, faceW, roll, upX, upY);
           let gx = 0, gy = 0;
           for (const p of lid) { gx += p[0]; gy += p[1]; }
           gx /= lid.length; gy /= lid.length;
@@ -751,13 +753,17 @@ void main() {
           ctx.closePath();
           ctx.fill();
         }
+        ctx.globalCompositeOperation = 'multiply'; // 後続のメイク描画用に戻す
+      }
 
-        if (settings.tearShadeA > 0) {
-          // 影線は塗りでなく細い線（太いと不自然）
-          ctx.strokeStyle = hexToRgba(settings.tearShadeColor, settings.tearShadeA * 0.5);
-          ctx.lineWidth = Math.max(0.8, faceW * 0.008);
-          ctx.lineCap = 'round';
-          ctx.lineJoin = 'round';
+      if (settings.tearShadeA > 0) {
+        // 影線は暗い色を暗く乗せるので multiply のまま。塗りでなく細い線（太いと不自然）
+        ctx.strokeStyle = hexToRgba(settings.tearShadeColor, settings.tearShadeA * 0.5);
+        ctx.lineWidth = Math.max(0.8, faceW * 0.008);
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+        for (const eye of [EYE_BOT_L, EYE_BOT_R]) {
+          const { lower } = tearBandPoints(eye, lm, W, H, faceW, roll, upX, upY);
           ctx.beginPath();
           ctx.moveTo(lower[0][0], lower[0][1]);
           for (let k = 1; k < lower.length; k++) ctx.lineTo(lower[k][0], lower[k][1]);

--- a/popup.html
+++ b/popup.html
@@ -197,6 +197,16 @@
     <label><span data-i18n="shadow_bias"></span> <input type="range" id="shadowBias" min="1" max="3" step="0.1"></label>
   </details>
 
+  <details data-fx="tear">
+    <summary><span data-i18n="tear_title"></span><input type="color" id="tearColor" class="hdr-color" data-i18n-title="tear_color_title" data-i18n-aria="tear_color_title"><input type="color" id="tearShadeColor" class="hdr-color" style="margin-left:3px" data-i18n-title="tear_shade_color_title" data-i18n-aria="tear_shade_color_title"></summary>
+    <label class="guide-row"><input type="checkbox" class="gt" data-guide="tear"><span data-i18n="guide_line"></span></label>
+    <label><span data-i18n="tear_a"></span> <input type="range" id="tearA" min="0" max="1" step="0.05"></label>
+    <label><span data-i18n="tear_shade_a"></span> <input type="range" id="tearShadeA" min="0" max="1" step="0.05"></label>
+    <label><span data-i18n="tear_h"></span> <input type="range" id="tearH" min="0.5" max="2" step="0.05"></label>
+    <label><span data-i18n="tear_w"></span> <input type="range" id="tearW" min="0.8" max="1.4" step="0.05"></label>
+    <label><span data-i18n="tear_soft"></span> <input type="range" id="tearSoft" min="0.5" max="3" step="0.1"></label>
+  </details>
+
   <details data-fx="liner">
     <summary><span data-i18n="liner_title"></span><input type="color" id="linerColor" class="hdr-color" data-i18n-title="liner_color_title" data-i18n-aria="liner_color_title"></summary>
     <label class="guide-row"><input type="checkbox" class="gt" data-guide="liner"><span data-i18n="guide_line"></span></label>

--- a/popup.js
+++ b/popup.js
@@ -1,7 +1,7 @@
 const DEFAULTS = MBF_DEFAULTS; // 初期値は defaults.js が単一情報源
 
-const RANGES = ['smooth', 'bright', 'warmth', 'sat', 'lipThresh', 'skinRange', 'nasoA', 'marioA', 'eyebagLine', 'eyebagBright', 'eyebagW', 'eyebagH', 'eyebagX', 'eyebagY', 'lipA', 'lipGloss', 'lipW', 'blushA', 'blushShape', 'blushX', 'blushY', 'blushSoft', 'browA', 'browW', 'browTaper', 'browArch', 'browPeak', 'browTail', 'shadowA', 'shadowH', 'shadowW', 'shadowSoft', 'shadowBias', 'linerA', 'linerW', 'linerY', 'linerWing', 'linerWingUp', 'linerWingW', 'noseA', 'noseW', 'noseIn', 'noseSoft', 'jawA', 'jawSoft', 'hiA', 'hiW', 'hiSoft', 'hiCheekA', 'hiCheekW', 'hiCheekX', 'hiCheekY', 'hiCheekSoft', 'hiChinA', 'hiChinW', 'hiChinY', 'hiChinSoft'];
-const COLORS = ['lipColor', 'blushColor', 'browColor', 'shadowColor', 'shadowColor2', 'shadowColor3', 'linerColor', 'shadeColor', 'hiColor'];
+const RANGES = ['smooth', 'bright', 'warmth', 'sat', 'lipThresh', 'skinRange', 'nasoA', 'marioA', 'eyebagLine', 'eyebagBright', 'eyebagW', 'eyebagH', 'eyebagX', 'eyebagY', 'lipA', 'lipGloss', 'lipW', 'blushA', 'blushShape', 'blushX', 'blushY', 'blushSoft', 'browA', 'browW', 'browTaper', 'browArch', 'browPeak', 'browTail', 'shadowA', 'shadowH', 'shadowW', 'shadowSoft', 'shadowBias', 'tearA', 'tearShadeA', 'tearH', 'tearW', 'tearSoft', 'linerA', 'linerW', 'linerY', 'linerWing', 'linerWingUp', 'linerWingW', 'noseA', 'noseW', 'noseIn', 'noseSoft', 'jawA', 'jawSoft', 'hiA', 'hiW', 'hiSoft', 'hiCheekA', 'hiCheekW', 'hiCheekX', 'hiCheekY', 'hiCheekSoft', 'hiChinA', 'hiChinW', 'hiChinY', 'hiChinSoft'];
+const COLORS = ['lipColor', 'blushColor', 'browColor', 'shadowColor', 'shadowColor2', 'shadowColor3', 'tearColor', 'tearShadeColor', 'linerColor', 'shadeColor', 'hiColor'];
 
 const CHECKS = ['enabled', 'shadowUse2', 'shadowUse3'];
 
@@ -41,6 +41,7 @@ const FX_KEYS = {
   blush: ['blushA'],
   brow: ['browA'],
   shadow: ['shadowA'],
+  tear: ['tearA', 'tearShadeA'],
   liner: ['linerA'],
   shade: ['noseA', 'jawA'],
   hi: ['hiA', 'hiCheekA', 'hiChinA']


### PR DESCRIPTION
## 概要

涙袋メイク（下瞼のアイシャドウ）を**ハイライト + シェイドの2層**で追加しました。ストアレビューの要望に対応するものです。

明るい色を乗せるだけでは「ぷっくり」した立体感が出ないため、帯の下端に**細い影線**を引きます（影線が立体感の正体）。影線は塗りではなく線で描いています（太いと不自然になるため）。

## 帯の座標生成は実描画とガイドで共有

`tearBandPoints(eye, lm, W, H, faceW, roll, upX, upY)` に切り出し、実描画と `drawGuide` の両方から呼びます（#33 のレビューで「座標生成を共有しないガイドは実描画とずれる」が確定しているため）。

戻り値は3つ:

- `lid` … 下まぶたの際側の点列（`tearW` で顔の横方向にのみ伸縮）
- `lower` … `lid` を顔基準の下方向へ `faceW * 0.03 * tearH` 押し出した点列。**目尻・目頭側は 0.4 倍に狭める**（自然な紡錘形にするため）
- `drop` … 押し出し量（グラデーションの終点計算に使う）

シェイド線は `lower` の辺に沿って引くので、ハイライト帯の下端と必ず一致します。

| 呼び出し元 | 用途 |
|---|---|
| `drawMakeup` の涙袋ブロック | ハイライトの塗り（`lid` → `lower` 逆順で閉じる）+ シェイド線（`lower` に沿って stroke） |
| `drawGuide` の涙袋ブロック | `lid.concat(lower.reverse())` を `strokePoints` で描く |

**実描画とガイドが同一の頂点列をたどることを数値で確認しました**（18頂点・最大偏差 **0**）。端の押し出しが中央の 0.400 倍になっていることも確認済みです。

## 描画の詳細

- **ハイライト**: 際側 `tearA * 0.45` → 下端 0 の縦グラデーション。`blur(faceW * 0.012 * tearSoft)`。**`screen` 合成**
- **シェイド**: `lineWidth = max(0.8, faceW * 0.008)`、アルファ `tearShadeA * 0.5`、`lineCap/lineJoin: round`、ハイライトと同じ blur。**`multiply` 合成のまま**
- 挿入位置はアイシャドウブロックの直後・アイラインブロックの直前

### 合成モード（レビュー指摘で修正）

初版はハイライトを `drawMakeup` の `multiply` 区間内で塗っていたため、**どんな肌色でも暗くなっていました**（multiply は `src < 255` の全チャンネルで `result <= dst`）。既存のハイライト・リップグロスと同じく `screen` に切り替えて描き、末尾で `multiply` に戻す形に修正しています。

影線は暗い色を暗く乗せるのが正しいため `multiply` のままです。合成モードの切り替えが左右の目で交互にならないよう、**ハイライト2目 → 影線2目の2パス**に分けました（切り替えは1往復のみ）。

`drawMakeup` 内の遷移（行番号）:

| 行 | 遷移 | 対象 |
|---|---|---|
| 588 | → `multiply` | drawMakeup 全体の既定 |
| 614 → 638 | `multiply` → `screen` → `multiply` | リップグロス（既存） |
| **739 → 756** | **`multiply` → `screen` → `multiply`** | **涙袋ハイライト（本 PR）** |
| 873 → 934 | `multiply` → `screen` → `multiply` | ハイライト3種（既存） |

涙袋の影線は 756 行の `multiply` 復帰より後にあるため `multiply` 区間内です。

既定色 `#f0d5cd` × 実効アルファ 0.45 で肌色4種の輝度変化を計算し、修正前後を確認しました:

| 肌色 | multiply（修正前） | screen（修正後） |
|---|---|---|
| 明るい肌 `[245,224,210]` | **−14.8** | **+10.6** |
| 標準 `[224,188,166]` | **−12.4** | **+23.0** |
| 中間 `[198,156,130]` | **−10.4** | **+34.8** |
| 濃い肌 `[120,86,66]` | **−5.4** | **+62.8** |

修正前は全肌色で暗転、修正後は全肌色で明転します（ハイライトとして正しい向き）。

後続の stroke ブロック（アイライン・輪郭シェーディング）はいずれも `lineWidth` / `lineCap` を自前で設定しているため、涙袋ブロックのキャンバス状態は漏れません（確認済み）。

## 配線チェックリスト

| ファイル | 追加内容 |
|---|---|
| `defaults.js` | `tearColor` / `tearShadeColor` / `tearA` / `tearShadeA` / `tearH` / `tearW` / `tearSoft`、`guideParts.tear: false`、`MBF_GUIDE_COLORS.tear: '#ff2ed1'` |
| `override.js` | `tearBandPoints()`、涙袋の描画ブロック、`drawGuide` の涙袋ブロック、`makeupOn` に `tearA` / `tearShadeA`、`GUIDE_COLORS.tear` |
| `popup.html` | `data-fx="tear"` セクション（アイシャドウとアイラインの間）、summary に色2個、先頭に「ガイド線」行、スライダー5本 |
| `popup.js` | `RANGES` に5件、`COLORS` に2件、`FX_KEYS` に `tear: ['tearA', 'tearShadeA']` |
| `_locales/{ja,en}` | `tear_title` / `tear_color_title` / `tear_shade_color_title` / `tear_a` / `tear_shade_a` / `tear_h` / `tear_w` / `tear_soft` / `guide_part_tear` |

ガイド線チェックは `[data-guide]` の自動巡回で拾われるため、`popup.js` 側の追加コードは不要でした。`bridge.js` は未変更です（`guideParts` の既存リセットが涙袋のガイドもそのままカバーします）。

## 英語ラベルを1件だけ issue の案から変えています

`guide_part_tear` の英語は issue の案が "Under-eye guide line" でしたが、これは**既存の `guide_part_eyebag`（クマ消し）と完全に同一の文字列**でした。ガイドトグルは「どのガイド線か」を識別するためのもので、しかも**涙袋とクマ消しの重なり確認がこの機能の主用途**（issue のテスト観点4）なので、同じ名前だと役に立ちません。`"Under-eye highlight guide line"` にしています。日本語は案どおり「涙袋のガイド線」（クマ消しは「クマ消しのガイド線」なので衝突なし）。

## 検証

- `node --check`: `override.js` / `popup.js` / `defaults.js` / `bridge.js` 全通過
- **`./scripts/package.sh` が通過**（ガイド色の二重管理の一致検証込み。`dist/simple-makeup-filter-v1.2.0.zip` を生成）
- `MBF_GUIDE_COLORS`（defaults）と `GUIDE_COLORS`（override）が**14件・キー順まで完全一致**、`tear` は両方 `#ff2ed1`
- `guideParts` 14キーと色定義14キーが一致、`data-guide` 14個と 1:1
- `_locales` ja/en とも **140キー・並び順まで一致**、片側のみのキーなし
- `RANGES`(62) / `COLORS`(11) の全キーが `MBF_DEFAULTS` と `popup.html` の input の両方に存在
- `popup.html` の `data-i18n*` 全キーが解決、`guide_part_*` の欠落なし（ja/en とも）
- **実描画とガイドの頂点列が完全一致（最大偏差 0）**、端の押し出し比 0.400

## 未検証（実機要）

実機（Meet + カメラ）が必要なため未確認です。**特に見た目の係数は実機ループでの調整が前提**で、初版は issue の係数のまま出しています:

- 帯の高さ（`faceW * 0.03 * tearH`）・シェイド線の細さ（`faceW * 0.008`）・グラデーションの止まり位置（際側 `0.45` → 下端 0）・アルファ（`tearShadeA * 0.5`）
- **ハイライトの実効アルファ `tearA * 0.45` は `screen` 化で見え方が変わります**（上表のとおり濃い肌ほど明転幅が大きい）。指示により係数はいじっていないので、強すぎ／弱すぎの判断は実機ループで
- issue のテスト観点1〜8:
  1. 濃さで明るい帯、影の濃さで細い影線が出る
  2. 両方 0 で何も描画されない
  3. 高さ・横幅・ぼかしが効く。顔を傾けても追従する
  4. **ガイド線（マゼンタ）が帯の輪郭と一致し、クマ消しのガイド（シアン）と同時表示で重なりを確認できる**（この機能の当初の動機）
  5. ガイドチェックが涙袋セクション内にあり、ON のたびに confirm、Meet リロードで消える
  6. プリセットに涙袋の設定値が含まれ、ガイド選択は含まれない
  7. 「すべて初期値に戻す」で 0 に戻る
  8. 日英でラベルが正しい

観点4 は静的には頂点列の完全一致まで確認済みですが、目視での照合はしていません。

Closes #38

