### PR TITLE
♻️ refactor: #41 帯描画の横方向伸縮と端の押し出し係数を共通化する

### DIFF
--- a/override.js
+++ b/override.js
@@ -280,7 +280,7 @@ void main() {
 
   // 点列 pts を重心基準に、顔の横方向（dirX, dirY）にだけ伸縮する（高さは変えない）
   function widenAlongFace(pts, dirX, dirY, widen) {
-    if (widen === 0) return pts;
+    if (widen === 0) return pts.map(([x, y]) => [x, y]);
     let cx = 0, cy = 0;
     for (const p of pts) { cx += p[0]; cy += p[1]; }
     cx /= pts.length; cy /= pts.length;

--- a/override.js
+++ b/override.js
@@ -270,10 +270,24 @@ void main() {
   const LASH_VAR_B = [0.28, 0.83, 0.47, 0.71, 0.05, 0.92, 0.36, 0.58, 0.15, 0.79, 0.44, 0.66, 0.22];
   const LASH_VAR_C = [0.73, 0.11, 0.52, 0.88, 0.26, 0.64, 0.39, 0.97, 0.18];
   const LASH_VAR_D = [0.45, 0.81, 0.07, 0.59, 0.34, 0.91, 0.23];
+  // 帯状パーツ（アイシャドウ・涙袋等）の端点押し出しを狭める係数。紡錘形にするため
+  const BAND_EDGE_TAPER = 0.4;
 
   // テーブルを本のインデックスで循環参照し、-1〜1 に写す（決定的）
   function lashVar(table, i) {
     return table[i % table.length] * 2 - 1;
+  }
+
+  // 点列 pts を重心基準に、顔の横方向（dirX, dirY）にだけ伸縮する（高さは変えない）
+  function widenAlongFace(pts, dirX, dirY, widen) {
+    if (widen === 0) return pts;
+    let cx = 0, cy = 0;
+    for (const p of pts) { cx += p[0]; cy += p[1]; }
+    cx /= pts.length; cy /= pts.length;
+    return pts.map(([x, y]) => {
+      const d = (x - cx) * dirX + (y - cy) * dirY;
+      return [x + dirX * d * widen, y + dirY * d * widen];
+    });
   }
 
   function tracePath(ctx, lm, indices, W, H) {
@@ -556,20 +570,11 @@ void main() {
     const drop = faceW * 0.03 * settings.tearH;
     const dirX = Math.cos(roll), dirY = Math.sin(roll);
     const widen = settings.tearW - 1;
-    let lid = eye.map((i) => [lm[i].x * W, lm[i].y * H]);
     // 幅: 目の中心を基準に、顔の横方向にだけ伸縮（高さは変えない）
-    if (widen !== 0) {
-      let cx = 0, cy = 0;
-      for (const p of lid) { cx += p[0]; cy += p[1]; }
-      cx /= lid.length; cy /= lid.length;
-      lid = lid.map(([x, y]) => {
-        const d = (x - cx) * dirX + (y - cy) * dirY;
-        return [x + dirX * d * widen, y + dirY * d * widen];
-      });
-    }
+    const lid = widenAlongFace(eye.map((i) => [lm[i].x * W, lm[i].y * H]), dirX, dirY, widen);
     // 目尻・目頭側は押し出しを狭めて自然な紡錘形にする
     const lower = lid.map(([x, y], k) => {
-      const edge = k === 0 || k === lid.length - 1 ? 0.4 : 1;
+      const edge = k === 0 || k === lid.length - 1 ? BAND_EDGE_TAPER : 1;
       return [x - upX * drop * edge, y - upY * drop * edge];
     });
     return { lid, lower, drop };
@@ -784,17 +789,8 @@ void main() {
       const dirX = Math.cos(roll), dirY = Math.sin(roll); // 顔基準の「横」方向
       const widen = settings.shadowW - 1;
       for (const eye of [EYE_TOP_L, EYE_TOP_R]) {
-        let lid = eye.map((i) => [lm[i].x * W, lm[i].y * H]);
         // 幅: 目の中心を基準に、顔の横方向にだけ伸縮（高さは変えない）
-        if (widen !== 0) {
-          let cx = 0, cy = 0;
-          for (const p of lid) { cx += p[0]; cy += p[1]; }
-          cx /= lid.length; cy /= lid.length;
-          lid = lid.map(([x, y]) => {
-            const d = (x - cx) * dirX + (y - cy) * dirY;
-            return [x + dirX * d * widen, y + dirY * d * widen];
-          });
-        }
+        const lid = widenAlongFace(eye.map((i) => [lm[i].x * W, lm[i].y * H]), dirX, dirY, widen);
         // グラデーション: 際 → (中間) → (上)。オフの色は飛ばして使う色だけ等間隔に並べる。
         // 1色のときは同じ色が上に向かって薄く抜ける
         let gx = 0, gy = 0;
@@ -824,7 +820,7 @@ void main() {
         for (let k = 1; k < lid.length; k++) ctx.lineTo(lid[k][0], lid[k][1]);
         // 上方向へ押し出した辺を逆順でたどって閉じる（目尻・目頭側は少し狭める）
         for (let k = lid.length - 1; k >= 0; k--) {
-          const edge = k === 0 || k === lid.length - 1 ? 0.4 : 1;
+          const edge = k === 0 || k === lid.length - 1 ? BAND_EDGE_TAPER : 1;
           ctx.lineTo(lid[k][0] + upX * lift * edge, lid[k][1] + upY * lift * edge);
         }
         ctx.closePath();
@@ -1178,19 +1174,10 @@ void main() {
       const dirX = Math.cos(roll), dirY = Math.sin(roll);
       const widen = settings.shadowW - 1;
       for (const eye of [EYE_TOP_L, EYE_TOP_R]) {
-        let lid = eye.map((i) => [lm[i].x * W, lm[i].y * H]);
-        if (widen !== 0) {
-          let cx = 0, cy = 0;
-          for (const p of lid) { cx += p[0]; cy += p[1]; }
-          cx /= lid.length; cy /= lid.length;
-          lid = lid.map(([x, y]) => {
-            const d = (x - cx) * dirX + (y - cy) * dirY;
-            return [x + dirX * d * widen, y + dirY * d * widen];
-          });
-        }
+        const lid = widenAlongFace(eye.map((i) => [lm[i].x * W, lm[i].y * H]), dirX, dirY, widen);
         const band = lid.slice();
         for (let k = lid.length - 1; k >= 0; k--) {
-          const edge = k === 0 || k === lid.length - 1 ? 0.4 : 1;
+          const edge = k === 0 || k === lid.length - 1 ? BAND_EDGE_TAPER : 1;
           band.push([lid[k][0] + upX * lift * edge, lid[k][1] + upY * lift * edge]);
         }
         strokePoints(GUIDE_COLORS.shadow, band, true);


### PR DESCRIPTION
## 概要

「点列を顔の横方向にだけ伸縮する」処理と「端点の押し出しを 0.4 倍に狭める」係数が `override.js` 内の複数箇所（涙袋・アイシャドウ実描画・アイシャドウのガイド）に重複していたため、共通関数・共通定数に抽出した。描画結果を変えないリファクタ。

## 変更ファイル

- `override.js`
  - `widenAlongFace(pts, dirX, dirY, widen)` を追加し、`tearBandPoints` 内・アイシャドウ実描画・アイシャドウガイドの3箇所にあった横方向伸縮の重複コードを置き換え
  - 端点押し出しのマジックナンバー `0.4` を定数 `BAND_EDGE_TAPER` にして、涙袋・アイシャドウ実描画・アイシャドウガイドの3箇所から参照するように変更

## 検証

- 抽出前後で同一入力に対する出力座標が一致することを node で数値確認済み（抽出前のインラインロジックと抽出後の実コードから正規表現で切り出した `widenAlongFace`/`BAND_EDGE_TAPER` を、widen の正負・0・roll・up ベクトルを変えた複数パターンで比較し、全て完全一致）
- `node --check override.js` で構文確認済み
- テストコードは追加していない（issue の指定通り）。実機での目視確認は未実施

## 注意点

- テストコードは書かない方針（issue 記載）。実機でアイシャドウ・涙袋の見た目が変わっていないことの目視確認はレビュー側で実施をお願いします

Closes #41
