### PR TITLE
♻️ refactor: #44 アイシャドウの帯組み立てを実描画とガイドで共通化する

### DIFF
--- a/override.js
+++ b/override.js
@@ -563,6 +563,24 @@ void main() {
     return pts;
   }
 
+  // アイシャドウの帯: 上まぶたの際ラインを顔基準の上方向へ押し出した閉領域。
+  // lid = 際側の点列、band = lid + 押し出し辺を逆順にたどった閉領域の全点列。
+  // 実描画と位置ガイドで同じ形を使う
+  function shadowBandPoints(eye, lm, W, H, faceW, roll, upX, upY) {
+    const lift = faceW * 0.055 * settings.shadowH;
+    const dirX = Math.cos(roll), dirY = Math.sin(roll);
+    const widen = settings.shadowW - 1;
+    // 幅: 目の中心を基準に、顔の横方向にだけ伸縮（高さは変えない）
+    const lid = widenAlongFace(eye.map((i) => [lm[i].x * W, lm[i].y * H]), dirX, dirY, widen);
+    const band = lid.slice();
+    // 上方向へ押し出した辺を逆順でたどって閉じる（目尻・目頭側は少し狭めて紡錘形にする）
+    for (let k = lid.length - 1; k >= 0; k--) {
+      const edge = k === 0 || k === lid.length - 1 ? BAND_EDGE_TAPER : 1;
+      band.push([lid[k][0] + upX * lift * edge, lid[k][1] + upY * lift * edge]);
+    }
+    return { lid, band, lift };
+  }
+
   // 涙袋の帯: 下まぶたの際ラインを顔基準の下方向へ押し出した閉領域。
   // lid = 際側の点列、drop = 押し出した側の点列（シェイド線はこの辺に沿って引く）。
   // 実描画と位置ガイドで同じ形を使う
@@ -785,12 +803,8 @@ void main() {
       // アイシャドウ: 上まぶたの際ラインを顔基準の上方向へ押し出した帯を塗る。
       // 際側が濃く上端へ向かって薄くなるよう、ぼかし + multiply で馴染ませる
       ctx.filter = `blur(${Math.max(2, faceW * 0.015 * settings.shadowSoft)}px)`;
-      const lift = faceW * 0.055 * settings.shadowH;
-      const dirX = Math.cos(roll), dirY = Math.sin(roll); // 顔基準の「横」方向
-      const widen = settings.shadowW - 1;
       for (const eye of [EYE_TOP_L, EYE_TOP_R]) {
-        // 幅: 目の中心を基準に、顔の横方向にだけ伸縮（高さは変えない）
-        const lid = widenAlongFace(eye.map((i) => [lm[i].x * W, lm[i].y * H]), dirX, dirY, widen);
+        const { lid, band, lift } = shadowBandPoints(eye, lm, W, H, faceW, roll, upX, upY);
         // グラデーション: 際 → (中間) → (上)。オフの色は飛ばして使う色だけ等間隔に並べる。
         // 1色のときは同じ色が上に向かって薄く抜ける
         let gx = 0, gy = 0;
@@ -816,13 +830,8 @@ void main() {
         }
         ctx.fillStyle = g;
         ctx.beginPath();
-        ctx.moveTo(lid[0][0], lid[0][1]);
-        for (let k = 1; k < lid.length; k++) ctx.lineTo(lid[k][0], lid[k][1]);
-        // 上方向へ押し出した辺を逆順でたどって閉じる（目尻・目頭側は少し狭める）
-        for (let k = lid.length - 1; k >= 0; k--) {
-          const edge = k === 0 || k === lid.length - 1 ? BAND_EDGE_TAPER : 1;
-          ctx.lineTo(lid[k][0] + upX * lift * edge, lid[k][1] + upY * lift * edge);
-        }
+        ctx.moveTo(band[0][0], band[0][1]);
+        for (let k = 1; k < band.length; k++) ctx.lineTo(band[k][0], band[k][1]);
         ctx.closePath();
         ctx.fill();
       }
@@ -1170,16 +1179,8 @@ void main() {
     }
 
     if (settings.shadowA > 0 && partOn('shadow')) {
-      const lift = faceW * 0.055 * settings.shadowH;
-      const dirX = Math.cos(roll), dirY = Math.sin(roll);
-      const widen = settings.shadowW - 1;
       for (const eye of [EYE_TOP_L, EYE_TOP_R]) {
-        const lid = widenAlongFace(eye.map((i) => [lm[i].x * W, lm[i].y * H]), dirX, dirY, widen);
-        const band = lid.slice();
-        for (let k = lid.length - 1; k >= 0; k--) {
-          const edge = k === 0 || k === lid.length - 1 ? BAND_EDGE_TAPER : 1;
-          band.push([lid[k][0] + upX * lift * edge, lid[k][1] + upY * lift * edge]);
-        }
+        const { band } = shadowBandPoints(eye, lm, W, H, faceW, roll, upX, upY);
         strokePoints(GUIDE_COLORS.shadow, band, true);
       }
     }

--- a/override.js
+++ b/override.js
@@ -572,7 +572,7 @@ void main() {
     const widen = settings.shadowW - 1;
     // 幅: 目の中心を基準に、顔の横方向にだけ伸縮（高さは変えない）
     const lid = widenAlongFace(eye.map((i) => [lm[i].x * W, lm[i].y * H]), dirX, dirY, widen);
-    const band = lid.slice();
+    const band = lid.map(([x, y]) => [x, y]);
     // 上方向へ押し出した辺を逆順でたどって閉じる（目尻・目頭側は少し狭めて紡錘形にする）
     for (let k = lid.length - 1; k >= 0; k--) {
       const edge = k === 0 || k === lid.length - 1 ? BAND_EDGE_TAPER : 1;


### PR DESCRIPTION
## 概要

アイシャドウの「帯（band）の閉領域を組み立てる」処理が実描画とガイド描画に重複していたのを、`tearBandPoints` と同じ形式の共通関数 `shadowBandPoints` に抽出した。

## 変更ファイル

- `override.js`
  - `shadowBandPoints(eye, lm, W, H, faceW, roll, upX, upY)` を追加。`widenAlongFace` で伸縮した際ライン（`lid`）と、`upX/upY` 方向へ `lift` 押し出して閉じた帯（`band`。目尻・目頭側は `BAND_EDGE_TAPER` で狭める）を返す。`lift` の計算もこの関数に集約した
  - 実描画ブロック（グラデーション塗り）とガイド描画ブロック（`drawGuide` 内）の両方から `shadowBandPoints` を呼ぶように置き換え、重複していた組み立てロジックを削除

## 注意点

- リファクタのみで描画結果は変えていない。抽出前後で `widenAlongFace` / `BAND_EDGE_TAPER` / 実描画ブロック・ガイドブロックを override.js の実コードから node で切り出し、同一入力（決定的なダミーランドマーク）を与えて出力（グラデーション座標・パス点列）が完全一致することを数値確認済み
- 実描画側のグラデーション中心（`gx/gy`）は `shadowBandPoints` が返す `lid` に依存しているが、上記の数値確認でグラデーション生成座標も一致することを確認済み
- `shadowBandPoints` は呼び出しごとに新規配列を返す（`lid`/`band` とも引数のランドマークをエイリアスしない）ことを検証済み

## テスト

- `node --check override.js`: 構文チェック OK
- `scripts/package.sh` のガイド色一致検証部分を単体実行: OK（今回の変更は対象外だが念のため）
- 抽出前後の数値比較（node、実コード切り出し）: 完全一致
- 実機でのアイシャドウ実描画・ガイド表示の目視確認は未実施（vendor 同梱の実機確認環境はあるが、今回はコード上の座標一致検証で完了と判断。念のためレビューで実機確認を推奨）

Closes #44
