### PR TITLE
🐛 fix: #46 ほうれい線とマリオネットラインの片方だけ有効時に無効側の処理が毎フレーム空回りする

### DIFF
--- a/override.js
+++ b/override.js
@@ -353,44 +353,47 @@ void main() {
     const raw = settings.nasoA;
     const rawM = settings.marioA;
     if (raw <= 0 && rawM <= 0) return;
-    // 1.0 までは不透明度、それ以上はぼかしの強さとパッチの太さを増やして消す力を上げる
-    const a = Math.min(1, raw);
-    const boost = Math.max(1, raw);
 
     const faceW = Math.hypot(
       (lm[FACE_RIGHT].x - lm[FACE_LEFT].x) * W,
       (lm[FACE_RIGHT].y - lm[FACE_LEFT].y) * H
     );
     const mctx = mask.getContext('2d');
-    mctx.clearRect(0, 0, W, H);
-
-    for (const [alaI, mouthI] of [[ALA_L, MOUTH_L], [ALA_R, MOUTH_R]]) {
-      const { cx, cy, rx, ry, angle } = grooveEllipse(lm, W, H, faceW, alaI, mouthI, boost);
-      mctx.save();
-      mctx.translate(cx, cy);
-      mctx.rotate(angle);
-      mctx.scale(rx / ry, 1); // 溝に沿った細長い楕円
-      const g = mctx.createRadialGradient(0, 0, 0, 0, 0, ry);
-      g.addColorStop(0, `rgba(0,0,0,${a})`);
-      g.addColorStop(0.7, `rgba(0,0,0,${a * 0.6})`);
-      g.addColorStop(1, 'rgba(0,0,0,0)');
-      mctx.fillStyle = g;
-      mctx.beginPath();
-      mctx.arc(0, 0, ry, 0, Math.PI * 2);
-      mctx.fill();
-      mctx.restore();
-    }
-
     const pctx = patch.getContext('2d');
-    pctx.clearRect(0, 0, W, H);
-    pctx.filter = `blur(${Math.max(2, faceW * 0.02 * boost)}px)`;
-    pctx.drawImage(srcCanvas, 0, 0);
-    pctx.filter = 'none';
-    pctx.globalCompositeOperation = 'destination-in';
-    pctx.drawImage(mask, 0, 0);
-    pctx.globalCompositeOperation = 'source-over';
 
-    ctx.drawImage(patch, 0, 0);
+    if (raw > 0) {
+      // 1.0 までは不透明度、それ以上はぼかしの強さとパッチの太さを増やして消す力を上げる
+      const a = Math.min(1, raw);
+      const boost = Math.max(1, raw);
+
+      mctx.clearRect(0, 0, W, H);
+      for (const [alaI, mouthI] of [[ALA_L, MOUTH_L], [ALA_R, MOUTH_R]]) {
+        const { cx, cy, rx, ry, angle } = grooveEllipse(lm, W, H, faceW, alaI, mouthI, boost);
+        mctx.save();
+        mctx.translate(cx, cy);
+        mctx.rotate(angle);
+        mctx.scale(rx / ry, 1); // 溝に沿った細長い楕円
+        const g = mctx.createRadialGradient(0, 0, 0, 0, 0, ry);
+        g.addColorStop(0, `rgba(0,0,0,${a})`);
+        g.addColorStop(0.7, `rgba(0,0,0,${a * 0.6})`);
+        g.addColorStop(1, 'rgba(0,0,0,0)');
+        mctx.fillStyle = g;
+        mctx.beginPath();
+        mctx.arc(0, 0, ry, 0, Math.PI * 2);
+        mctx.fill();
+        mctx.restore();
+      }
+
+      pctx.clearRect(0, 0, W, H);
+      pctx.filter = `blur(${Math.max(2, faceW * 0.02 * boost)}px)`;
+      pctx.drawImage(srcCanvas, 0, 0);
+      pctx.filter = 'none';
+      pctx.globalCompositeOperation = 'destination-in';
+      pctx.drawImage(mask, 0, 0);
+      pctx.globalCompositeOperation = 'source-over';
+
+      ctx.drawImage(patch, 0, 0);
+    }
 
     if (rawM > 0) {
       const aM = Math.min(1, rawM);


### PR DESCRIPTION
## 概要

`drawNasoFix` の早期リターンが「ほうれい線補正（`nasoA`）とマリオネットライン補正（`marioA`）が両方 0」の場合しか抜けないため、片方だけ 0 の場合に無効側のブロック（全画面ぼかしを含む）が毎フレーム空回りしていた不具合を修正した。ほうれい線ブロックを `if (raw > 0) { ... }` で囲み、マリオネットブロック（既に `if (rawM > 0)` で囲まれていた）と対称にした。

## 変更ファイル

- `override.js`
  - `drawNasoFix` 内のほうれい線ブロック（マスクへの楕円グラデーション描画 + ぼかし付き `drawImage` + `destination-in` 合成 + 出力への `drawImage`）を `if (raw > 0)` で囲んだ
  - `mctx` / `pctx` の取得は両ブロックで共有するため関数冒頭に残した（元々マリオネットブロックも同じ `mctx`/`pctx` を再利用していたため）
  - 冒頭の早期リターン（両方 0 で return）は維持
  - 描画結果・実行順序は変更していない（両方 > 0 の場合は従来と同一の処理が同一順序で走る）

## 検証内容

- `node --check override.js`: 構文エラーなし
- リーダー指示に基づき、`override.js` から `drawNasoFix` / `grooveEllipse` を切り出し、記録用のフェイク `ctx`/`canvas` を与えて描画コマンド列を実測するトレーススクリプトを用意して確認:
  - `nasoA > 0, marioA > 0`: 修正前後で描画コマンド列が完全一致（IDENTICAL）
  - `nasoA = 0, marioA > 0`（issue のバグ再現ケース）: 修正前は 68 件（ほうれい線ブロックの空回り 34 件を含む）→ 修正後は 34 件（マリオネットブロックのみ）で空回りが消えたことを確認
  - `nasoA > 0, marioA = 0`: 修正後もほうれい線ブロックのみ 34 件実行（マリオネット側は元々正しかった）
  - `nasoA = 0, marioA = 0`: 描画コマンド 0 件（即 return）

## 注意点

- テストコードは追加していない（issue の指示どおり。`node --check` + 上記トレース確認のみ）
- 実機での目視確認（ほうれい線・マリオネットライン両方有効時の見た目が従来と変わらないこと）は、リーダー指示によりユーザーが後でまとめて行う運用のため本 PR には含めていない

Closes #46
