### PR TITLE
🔧 chore: #54 blushSoft の値域一致を package.sh で検証する

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -50,18 +50,18 @@ python3 - <<'PY'
 import re, sys
 
 html = open('popup.html', encoding='utf-8').read()
-m = re.search(r'id="blushSoft"[^>]*\bmin="([^"]+)"[^>]*\bmax="([^"]+)"', html)
-if not m:
-    print('ERROR: popup.html に id="blushSoft" の min/max 属性が見つかりません', file=sys.stderr)
+html_hits = re.findall(r'id="blushSoft"[^>]*\bmin="([^"]+)"[^>]*\bmax="([^"]+)"', html)
+if len(html_hits) != 1:
+    print(f'ERROR: popup.html の id="blushSoft" min/max 属性が {len(html_hits)} 件ヒットしました（1件のはず）', file=sys.stderr)
     sys.exit(1)
-html_min, html_max = m.group(1), m.group(2)
+html_min, html_max = html_hits[0]
 
 js = open('override.js', encoding='utf-8').read()
-m2 = re.search(r'Math\.min\(([\d.]+),\s*Math\.max\(([\d.]+),\s*settings\.blushSoft\)\)', js)
-if not m2:
-    print('ERROR: override.js に blushSoft のクランプ式が見つかりません', file=sys.stderr)
+js_hits = re.findall(r'Math\.min\(([\d.]+),\s*Math\.max\(([\d.]+),\s*settings\.blushSoft\)\)', js)
+if len(js_hits) != 1:
+    print(f'ERROR: override.js の blushSoft クランプ式が {len(js_hits)} 件ヒットしました（1件のはず）', file=sys.stderr)
     sys.exit(1)
-js_max, js_min = m2.group(1), m2.group(2)
+js_max, js_min = js_hits[0]
 
 if (html_min, html_max) != (js_min, js_max):
     print('ERROR: blushSoft の値域が popup.html と override.js で一致しません', file=sys.stderr)

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -43,6 +43,33 @@ if a != b:
     sys.exit(1)
 PY
 
+# blushSoft の値域（popup.html のスライダー属性と override.js のクランプ式）が
+# 食い違うと、スライダーで選べる値をクランプが黙って潰す（または範囲外の値が素通りする）ため、
+# 提出前に一致を検証する
+python3 - <<'PY'
+import re, sys
+
+html = open('popup.html', encoding='utf-8').read()
+m = re.search(r'id="blushSoft"[^>]*\bmin="([^"]+)"[^>]*\bmax="([^"]+)"', html)
+if not m:
+    print('ERROR: popup.html に id="blushSoft" の min/max 属性が見つかりません', file=sys.stderr)
+    sys.exit(1)
+html_min, html_max = m.group(1), m.group(2)
+
+js = open('override.js', encoding='utf-8').read()
+m2 = re.search(r'Math\.min\(([\d.]+),\s*Math\.max\(([\d.]+),\s*settings\.blushSoft\)\)', js)
+if not m2:
+    print('ERROR: override.js に blushSoft のクランプ式が見つかりません', file=sys.stderr)
+    sys.exit(1)
+js_max, js_min = m2.group(1), m2.group(2)
+
+if (html_min, html_max) != (js_min, js_max):
+    print('ERROR: blushSoft の値域が popup.html と override.js で一致しません', file=sys.stderr)
+    print(f'  popup.html  : min={html_min} max={html_max}', file=sys.stderr)
+    print(f'  override.js : min={js_min} max={js_max}', file=sys.stderr)
+    sys.exit(1)
+PY
+
 VERSION=$(python3 -c "import json; print(json.load(open('manifest.json'))['version'])")
 OUT="dist/simple-makeup-filter-v${VERSION}.zip"
 mkdir -p dist


### PR DESCRIPTION
## 概要

チークのぼかし係数 `blushSoft` の値域（1〜2.2）が `popup.html` のスライダー属性と `override.js` のクランプ式の2箇所で二重管理されている問題に対し、`scripts/package.sh` に一致検証を追加した。既存のガイド色検証（#35）と同型の対応。

## 変更ファイル

- `scripts/package.sh`
  - `popup.html` の `id="blushSoft"` の `min`/`max` 属性と、`override.js` のクランプ式（`Math.min(2.2, Math.max(1, settings.blushSoft))`）の定数を正規表現で抽出し、突合する検証を追加
  - 抽出に失敗した場合（0件ヒット）もエラーとして exit 1 にする
  - 値が不一致の場合は exit 1 で package.sh を失敗させる

## 確認内容

- `./scripts/package.sh` が現状の一致状態で成功することを確認
- ミューテーション確認（両側、確認後は元に戻し済み）
  - `popup.html` の `max` を一時的に `3.0` に変更 → 検証が exit 1 で失敗することを確認
  - `override.js` のクランプ定数を一時的に `2.5` に変更 → 検証が exit 1 で失敗することを確認
- 変更後 `git status --short` で戻し漏れ・残骸が無いことを確認済み（`scripts/package.sh` のみ差分が残る）

## 注意点

テストコードは書いていない（issue の指定通り）。`dist/` は git 管理外のためコミットに含めていない。

Closes #54
