### PR TITLE
📝 docs: #62 docs/store-listing.md の役目を終えたスクリーンショット計画セクションを削除する

### DIFF
--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -105,11 +105,3 @@ Fine-tune every detail with sliders and create your perfect look.
 • This extension is unofficial. Google Meet is a trademark of Google LLC.
 • Face-tracking features (makeup, etc.) may vary in performance depending on your PC.
 
----
-
-## スクリーンショット（1280x800、最低1枚・推奨5枚）※要準備
-1. ポップアップ UI 全体（アコーディオンを開いた状態）
-2. 美肌 before/after の比較
-3. メイク適用例（リップ・チーク・アイシャドウ）
-4. プリセット機能
-5. プライバシー説明の図（映像がPCから出ないことの図解）


### PR DESCRIPTION
## Summary

`docs/store-listing.md` の末尾にある「## スクリーンショット」セクション（108行目の区切り線 `---` から115行目）を削除しました。このセクションは Chrome Web Store 初提出前に書いた「これから撮る」作業メモであり、撮影・提出は完了しているため役目を終えています。

## 削除内容

- 108行目の区切り線 `---`
- 110〜115行目のスクリーンショット計画（5項目）

## 保持内容

以下のテキストは掲載文本体の一部として保持しています：

- 41行目：「• スクリーンショットの人物は AI 生成によるデモ画像です。」（日本語版）
- 104行目：「• Demo screenshots use AI-generated faces.」（英語版）

Closes #62