### PR TITLE
🔧 chore: #61 掲載文とmanifestのバージョン一致を package.sh で検証する

### DIFF
--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,5 +1,8 @@
 # Chrome ウェブストア掲載情報（下書き）
 
+## 対象バージョン
+1.2.0
+
 ## 名前（ja/en共通）
 Simple Makeup Filter for Google Meet
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -79,14 +79,14 @@ import json, re, sys
 manifest_version = json.load(open('manifest.json'))['version']
 
 listing = open('docs/store-listing.md', encoding='utf-8').read()
-listing_hits = re.findall(r'## 対象バージョン[ \t]*\n(\S+)', listing)
+listing_hits = re.findall(r'## 対象バージョン[ \t\r　]*\n(\S+)', listing)
 if len(listing_hits) != 1:
     print(f'ERROR: docs/store-listing.md の「## 対象バージョン」が {len(listing_hits)} 件ヒットしました（1件のはず）', file=sys.stderr)
     sys.exit(1)
 listing_version = listing_hits[0]
 
-if not re.match(r'^\d+\.\d+\.\d+$', listing_version):
-    print(f'ERROR: docs/store-listing.md の「## 対象バージョン」の値 ({listing_version}) がバージョン形式（例: 1.2.3）ではありません', file=sys.stderr)
+if not re.match(r'^\d+(\.\d+){0,3}$', listing_version):
+    print(f'ERROR: docs/store-listing.md の「## 対象バージョン」の値 ({listing_version}) がバージョン形式（数字をドットで区切った形式）ではありません', file=sys.stderr)
     sys.exit(1)
 
 if listing_version != manifest_version:

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -79,14 +79,18 @@ import json, re, sys
 manifest_version = json.load(open('manifest.json'))['version']
 
 listing = open('docs/store-listing.md', encoding='utf-8').read()
-m = re.search(r'## 対象バージョン\s*\n(\S+)', listing)
-if not m:
-    print('ERROR: docs/store-listing.md に「## 対象バージョン」が見つかりません', file=sys.stderr)
+listing_hits = re.findall(r'## 対象バージョン[ \t]*\n(\S+)', listing)
+if len(listing_hits) != 1:
+    print(f'ERROR: docs/store-listing.md の「## 対象バージョン」が {len(listing_hits)} 件ヒットしました（1件のはず）', file=sys.stderr)
     sys.exit(1)
-listing_version = m.group(1)
+listing_version = listing_hits[0]
+
+if not re.match(r'^\d+\.\d+\.\d+$', listing_version):
+    print(f'ERROR: docs/store-listing.md の「## 対象バージョン」の値 ({listing_version}) がバージョン形式（例: 1.2.3）ではありません', file=sys.stderr)
+    sys.exit(1)
 
 if listing_version != manifest_version:
-    print(f'掲載文の対象バージョン ({listing_version}) が manifest.json ({manifest_version}) と一致しません。', file=sys.stderr)
+    print(f'ERROR: 掲載文の対象バージョン ({listing_version}) が manifest.json ({manifest_version}) と一致しません', file=sys.stderr)
     print('docs/store-listing.md の機能一覧を確認し、「## 対象バージョン」を更新してください。', file=sys.stderr)
     print('（README.md の機能一覧もあわせて確認）', file=sys.stderr)
     sys.exit(1)

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -70,6 +70,28 @@ if (html_min, html_max) != (js_min, js_max):
     sys.exit(1)
 PY
 
+# 掲載文（docs/store-listing.md）の対象バージョンが manifest.json と食い違うと、
+# 機能を追加してもストア掲載文が更新されないまま提出される事故につながるため、
+# 提出前に一致を検証する
+python3 - <<'PY'
+import json, re, sys
+
+manifest_version = json.load(open('manifest.json'))['version']
+
+listing = open('docs/store-listing.md', encoding='utf-8').read()
+m = re.search(r'## 対象バージョン\s*\n(\S+)', listing)
+if not m:
+    print('ERROR: docs/store-listing.md に「## 対象バージョン」が見つかりません', file=sys.stderr)
+    sys.exit(1)
+listing_version = m.group(1)
+
+if listing_version != manifest_version:
+    print(f'掲載文の対象バージョン ({listing_version}) が manifest.json ({manifest_version}) と一致しません。', file=sys.stderr)
+    print('docs/store-listing.md の機能一覧を確認し、「## 対象バージョン」を更新してください。', file=sys.stderr)
+    print('（README.md の機能一覧もあわせて確認）', file=sys.stderr)
+    sys.exit(1)
+PY
+
 VERSION=$(python3 -c "import json; print(json.load(open('manifest.json'))['version'])")
 OUT="dist/simple-makeup-filter-v${VERSION}.zip"
 mkdir -p dist


### PR DESCRIPTION
## 概要

`docs/store-listing.md` に対象バージョンを明記し、`scripts/package.sh` に `manifest.json` の version との一致検証を追加した。機能追加時に掲載文の更新漏れが起きた事故（#58・#60）を受け、「バージョンを上げたら掲載文を見直したか」を機械的に気付ける仕組みを既存の検証（ガイド色二重管理・blushSoft 値域）と同じ書き方で追加する。

## 変更ファイル

- `docs/store-listing.md`: 冒頭に「## 対象バージョン」セクションを追加し、現在の `manifest.json` の version（1.2.0）を記載
- `scripts/package.sh`: `manifest.json` の `version` と `docs/store-listing.md` の「## 対象バージョン」を比較する検証を追加（既存のガイド色・blushSoft 値域検証と同じ Python ヒアドキュメント方式）。不一致の場合は警告メッセージを表示し終了コード 1 で止め、zip を生成しない。検証位置は zip 生成の直前（既存検証の並びの最後）

## ミューテーション検証（実測結果）

- **一致状態**: `./scripts/package.sh` を実行 → 検証をパスし `dist/simple-makeup-filter-v1.2.0.zip` が生成されることを確認
- **不一致状態**: `docs/store-listing.md` の対象バージョンを故意に `1.1.1` に書き換えて実行 → 以下のメッセージで終了コード 1 となり停止、`dist/` に zip が生成されないことを確認

  ```
  掲載文の対象バージョン (1.1.1) が manifest.json (1.2.0) と一致しません。
  docs/store-listing.md の機能一覧を確認し、「## 対象バージョン」を更新してください。
  （README.md の機能一覧もあわせて確認）
  ```

- 検証後、`docs/store-listing.md` を元の値（1.2.0）に戻し、再度一致状態でパスすることを確認済み（`git status` で残骸なし）
- 既存の検証（ガイド色・blushSoft 値域）も本変更後に引き続き動作することを確認済み

## レビュー対応（追加コミット）

以下3点をレビュー指摘に基づき修正した。

1. **エラーメッセージに `ERROR: ` プレフィックスがない**: 不一致時1行目を `ERROR: ` 付きに揃え、句点も既存に合わせて削除
2. **正規表現が空セクション時に次の見出しを値として採用する**: `## 対象バージョン\s*\n(\S+)` の `\s*` が改行を跨いで次の `##` 行を拾ってしまう問題を修正。改行を跨がない `[ \t]*` に変更し、取得した値がバージョン形式（`^\d+\.\d+\.\d+$`）であることを検証。形式不正なら専用メッセージで停止する
3. **`re.search` ではなく `re.findall` + 件数チェックにする**: 既存の blushSoft 検証と同じ書き方に統一し、見出しが複数ある場合も検出できるようにした

### 追加ミューテーション検証（実測結果）

- **「## 対象バージョン」の直下を空にする**: セクション本文を空行にして実行 → 正規表現が改行を跨がなくなったため次の見出しを誤って値として拾わず、`ERROR: docs/store-listing.md の「## 対象バージョン」が 0 件ヒットしました（1件のはず）` で停止し zip 未生成を確認
- **値がバージョン形式でない場合**（例: `TBD`）: `ERROR: docs/store-listing.md の「## 対象バージョン」の値 (TBD) がバージョン形式（例: 1.2.3）ではありません` で停止し zip 未生成を確認
- **「## 対象バージョン」セクションを2箇所に増やす**: ファイル末尾にもう1つ追加して実行 → `ERROR: docs/store-listing.md の「## 対象バージョン」が 2 件ヒットしました（1件のはず）` で停止し zip 未生成を確認
- 全て確認後 `git checkout -- docs/store-listing.md` で元に戻し、`git status` で残骸ゼロを確認済み

## 再レビュー対応（追加コミット）

以下2点を再レビュー指摘に基づき修正した。

1. **バージョン形式の検証が Chrome 仕様より厳しい**: `^\d+\.\d+\.\d+$`（3桁固定）は Chrome 拡張の manifest version 仕様（1〜4個のドット区切り整数。`1` / `1.1` / `1.2.3.4` すべて有効）より厳しく、このリポジトリが過去に出荷した `1.1`（2桁）のような形式でも次に採用した瞬間に package.sh が誤って停止する問題があった。`^\d+(\.\d+){0,3}$` に緩和し、エラーメッセージの例示（`例: 1.2.3`）も桁数を限定しない表現に変更した
2. **見出し行末の全角空白・CRLF で誤検知する**: `[ \t]*` が全角空白（U+3000）や `\r` にマッチせず、見出し行末にそれらが混入すると 0 件ヒットで停止していた。`[ \t\r　]*` に広げて対応（改行 `\n` は含めていない。改行を含めると前回修正した「空セクション時に次の見出しを拾う」欠陥が再発するため）

### 追加ミューテーション検証（実測結果）

- **一致状態**: 変更なしで `./scripts/package.sh` を実行 → パスし `dist/simple-makeup-filter-v1.2.0.zip` が生成されることを確認
- **2桁バージョンで一致**（今回の修正の主眼）: 掲載文の対象バージョンと `manifest.json` の version を両方 `1.1` にして実行 → パスし `dist/simple-makeup-filter-v1.1.zip` が生成されることを確認（修正前は形式エラーで停止していたケース）
- **4桁バージョンで一致**: 両方 `1.2.0.1` にして実行 → パスし `dist/simple-makeup-filter-v1.2.0.1.zip` が生成されることを確認
- **非バージョン文字列**: 対象バージョンを `TBD` にして実行 → `ERROR: docs/store-listing.md の「## 対象バージョン」の値 (TBD) がバージョン形式（数字をドットで区切った形式）ではありません` で停止し zip 未生成を確認（形式チェックの防御は維持）
- **「## 対象バージョン」の直下を空にする**: セクション本文を空行にして実行 → `ERROR: docs/store-listing.md の「## 対象バージョン」が 0 件ヒットしました（1件のはず）` で停止し zip 未生成を確認（前回塞いだ経路が維持されている）
- **セクションを2箇所に増やす**: ファイル末尾にもう1つ追加して実行 → `ERROR: docs/store-listing.md の「## 対象バージョン」が 2 件ヒットしました（1件のはず）` で停止し zip 未生成を確認
- 全角空白・CRLF 混入時に値を正しく取得できること、および改行を挟んだ空セクションでは依然として 0 件ヒットになる（前回修正の欠陥が再発していない）ことを、正規表現単体でも直接確認済み
- 全て確認後、`git checkout -- docs/store-listing.md manifest.json` で元に戻し、`git status` で残骸ゼロを確認済み

## 注意点

- この仕組みは「掲載文の内容が正しいこと」までは保証しない。「バージョンを上げた時に掲載文を見たか」を促す緩い仕組み（issue 記載の割り切り方針どおり）
- `package.sh` の検証パートの `scripts/verify.sh` への分離は今回のスコープ外（`.local/TODO.md` の later 案として別途判断）

Closes #61

