### PR TITLE
🐛 fix: #66 bridge の初回送信を get(null) ベースにして、defaults.js 未注入時でも保存済み設定が届くようにする

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -1,7 +1,7 @@
 // ISOLATED world。chrome.storage の設定を MAIN world (override.js) へ中継する
 // 初期値は defaults.js が単一情報源。
 // 万一 defaults.js が先に注入されていなくてもクラッシュさせない
-// （storage は popup 初回起動時に全キーが書き込まれるため、保存済みの値だけで動ける）
+// （sendCurrent は get(null) で storage を全量取得するため、DEFAULTS が空でも保存済みの値だけで動ける）
 const DEFAULTS = globalThis.MBF_DEFAULTS || {};
 
 function send(s) {
@@ -10,7 +10,13 @@ function send(s) {
 }
 
 function sendCurrent() {
-  chrome.storage.local.get(DEFAULTS, (s) => {
+  // get(null) で全量を取る: DEFAULTS が空（defaults.js 未注入）でも保存済み設定だけで動けるようにする。
+  // get(DEFAULTS) は DEFAULTS が {} のとき storage を一切読まない（空指定 = 空の結果が Chrome の仕様）
+  chrome.storage.local.get(null, (all) => {
+    const s = { ...DEFAULTS };
+    for (const k in all) {
+      if (!k.startsWith('__')) s[k] = all[k]; // __presets 等の UI 内部用キーは描画設定と無関係
+    }
     // MAIN world には chrome.runtime が無いので、vendor/ の URL をここから渡す
     s.__base = chrome.runtime.getURL('');
     s.guideParts = {};


### PR DESCRIPTION
## 概要

bridge.js の初回送信（`sendCurrent`）を `chrome.storage.local.get(DEFAULTS, ...)` から `get(null)`（全量取得）ベースに変更し、defaults.js が未注入で `DEFAULTS` が `{}` のときでも保存済み設定が MAIN world（override.js）に届くようにする。

`get(DEFAULTS)` は `DEFAULTS` が `{}` のとき storage を一切読まない（空指定 = 空の結果が Chrome の仕様）ため、defaults.js の注入に失敗した回はメイク・美肌の設定値が届かずフィルタが全 OFF になる穴があった。

## 変更ファイル

- `bridge.js`
  - `sendCurrent` を `get(null)` で全量取得し、`DEFAULTS` をフォールバックとしてマージする方式に変更
  - `__` 始まりの内部キー（`__presets` / `__introClosed` 等）は `onChanged` 側と同じ基準で除外
  - 冒頭コメントの根拠を `get(null)` 前提の記述に更新

## 注意点

- テストコードは追加していません（このリポジトリは実機の手動確認のみで、issue のテスト観点にもその旨記載あり）
- 実機確認（manifest から defaults.js を一時的に外して再現・修正確認する手順）はマージ前にリーダー側で実施予定
- spec/mock の更新は不要（設定中継の内部堅牢化のみで機能・UI・ストア掲載内容に変更なし）

Closes #66
