### PR TITLE
🔧 chore: #68 v1.2.1 リリース準備（バージョン bump と掲載文の対象バージョン更新）

### DIFF
--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,7 +1,7 @@
 # Chrome ウェブストア掲載情報（下書き）
 
 ## 対象バージョン
-1.2.0
+1.2.1
 
 ## 名前（ja/en共通）
 Simple Makeup Filter for Google Meet

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "default_locale": "ja",
   "description": "__MSG_extDescription__",
   "permissions": ["storage"],


### PR DESCRIPTION
## 概要

v1.2.1 リリース準備として、manifest.json とストア掲載文のバージョンを 1.2.0 → 1.2.1 に変更します。#66（defaults.js が注入されなかった回に保存済み設定が届かずフィルタが全 OFF になる穴の修正）を利用者に届けるためのリリースです。

## 変更ファイル

- `manifest.json`: バージョンを `1.2.0` → `1.2.1` に更新
- `docs/store-listing.md`: 対象バージョンを `1.2.0` → `1.2.1` に更新

## テスト確認

- `./scripts/package.sh` が成功し、`dist/simple-makeup-filter-v1.2.1.zip` が生成されることを確認
- zip 内 manifest.json の version が `1.2.1` であることを確認
- git diff がこの2ファイルの各1行だけであることを確認

Closes #68
